### PR TITLE
chore/2-implement-commitlint-for-conventional-commits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Description
+<!-- Describe your changes in detail -->
+
+## Related Issue
+<!-- Link to the issue this PR closes or relates to -->
+Closes #
+
+## Type of Change
+<!-- Mark the relevant option with an "x" -->
+- [ ] feat: New feature
+- [ ] fix: Bug fix
+- [ ] docs: Documentation
+- [ ] style: Code style (formatting, etc.)
+- [ ] refactor: Code refactoring
+- [ ] perf: Performance improvement
+- [ ] test: Adding/updating tests
+- [ ] chore: Build/tooling changes
+- [ ] ci: CI/CD changes
+
+## Testing
+<!-- How have you tested these changes? -->
+
+## Checklist
+- [ ] My commit messages follow the Conventional Commits format
+- [ ] I have tested my changes in Godot
+- [ ] I have updated documentation if needed
+- [ ] I have not broken any existing functionality

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,34 @@
+name: Commitlint
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  lint:
+    name: Lint Commit Messages
+    runs-on: ubuntu-latest
+    steps:
+      # Step 1: Checkout the PR code
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # Step 2: Set up Node.js environment
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      # Step 3: Install commitlint
+      - name: Install commitlint
+        run: |
+          npm install --save-dev @commitlint/{cli,config-conventional}
+
+      # Step 4: Lint commits in the PR
+      - name: Lint commit messages
+        run: |
+          npx commitlint --from origin/${{ github.base_ref }} --to HEAD --verbose

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,28 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'docs',
+        'style',
+        'refactor',
+        'perf',
+        'test',
+        'chore',
+        'ci',
+        'revert',
+      ],
+    ],
+    'type-case': [2, 'always', 'lowercase'],
+    'type-empty': [2, 'never'],
+    'scope-case': [2, 'always', 'lowercase'],
+    'subject-case': [2, 'never', ['start-case', 'pascal-case', 'upper-case']],
+    'subject-empty': [2, 'never'],
+    'subject-full-stop': [2, 'never', '.'],
+    'header-max-length': [2, 'always', 72],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "anino-visual-novel",
+  "version": "0.1.0",
+  "description": "Anino Visual Novel - A Godot 4.6 project",
+  "private": true,
+  "devDependencies": {
+    "@commitlint/cli": "^19.0.0",
+    "@commitlint/config-conventional": "^19.0.0"
+  },
+  "scripts": {
+    "commitlint": "commitlint"
+  }
+}


### PR DESCRIPTION
Implement automated commit linting using GitHub Actions to enforce the Conventional Commits standard across all pull requests. This ensures that commit messages follow the type(scope): message format, which allows for clean and automated changelog generation for the Alpha release.

Changes include:
- Created .github/workflows/commitlint.yml workflow
- Added commitlint.config.js configuration
- Created .github/pull_request_template.md for PR guidance
- Added package.json with commitlint dependencies
- Workflow blocks merging if commit messages don't match convention

Closes #2