### PR TITLE
fix(ci): resolve missing docker image error in godot export pipeline #40

### DIFF
--- a/.github/workflows/alpha_build_export.yml
+++ b/.github/workflows/alpha_build_export.yml
@@ -15,10 +15,11 @@ jobs:
       - name: Create Build Directories
         run: mkdir -p builds/windows builds/web
 
-      # Cache Docker layers (huge speed boost after first run)
+      # Docker Buildx
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Cache Docker layers
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
@@ -27,11 +28,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      # Build custom Godot CI image (future-proof deps)
+      # Cache Godot import cache
+      - name: Cache Godot files
+        uses: actions/cache@v4
+        with:
+          path: .godot
+          key: ${{ runner.os }}-godot-${{ hashFiles('project.godot') }}
+          restore-keys: |
+            ${{ runner.os }}-godot-
+
+      # Build CI image
       - name: Build Godot CI Image
         run: |
           cat <<EOF > Dockerfile
-          FROM barichello/godot-ci:mono-4.6
+          FROM barichello/godot-ci:4.6
 
           RUN apt-get update && apt-get install -y \
               fontconfig \
@@ -43,43 +53,59 @@ jobs:
           EOF
 
           docker buildx build \
+            --load \
             --cache-from=type=local,src=/tmp/.buildx-cache \
             --cache-to=type=local,dest=/tmp/.buildx-cache-new \
-            -t godot-ci-font \
+            -t godot-ci-font:latest \
             .
 
-      # Move cache (required workaround)
+      # ✅ VERIFY IMAGE EXISTS (prevents your error)
+      - name: Verify Docker Image Exists
+        run: |
+          docker images | grep godot-ci-font || (echo "Image not built!" && exit 1)
+
+      # Move cache safely
       - name: Move Docker cache
         run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          if [ -d "/tmp/.buildx-cache-new" ]; then
+            rm -rf /tmp/.buildx-cache
+            mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          fi
 
+      # Install export templates (NO project boot)
       - name: Install Export Templates
         run: |
           docker run --rm \
-            -v "$PWD":/project \
-            -w /project \
-            godot-ci-font \
-            godot --headless /project/project.godot --install-templates
+            godot-ci-font:latest \
+            godot --headless --no-window --quit --install-templates
 
+      # Windows Export
       - name: Export Windows Build
         run: |
+          echo "Windows export start: $(date)"
           docker run --rm \
             -v "$PWD":/project \
             -w /project \
-            godot-ci-font \
-            godot --headless /project/project.godot \
+            godot-ci-font:latest \
+            godot --headless --no-window /project/project.godot \
+            --skip-broken \
             --export-release "Windows Desktop" builds/windows/Alpha.exe
+          echo "Windows export done: $(date)"
 
+      # Web Export
       - name: Export Web Build
         run: |
+          echo "Web export start: $(date)"
           docker run --rm \
             -v "$PWD":/project \
             -w /project \
-            godot-ci-font \
-            godot --headless /project/project.godot \
-            --export-release "HTML5" builds/web/Alpha.html
+            godot-ci-font:latest \
+            godot --headless --no-window /project/project.godot \
+            --skip-broken \
+            --export-release "Web" builds/web/Alpha.html
+          echo "Web export done: $(date)"
 
+      # Upload artifacts
       - uses: actions/upload-artifact@v4
         with:
           name: Alpha-Windows

--- a/.github/workflows/alpha_build_export.yml
+++ b/.github/workflows/alpha_build_export.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Install Export Templates
         run: |
           docker run --rm \
+            -v godot-templates:/root/.local/share/godot \
             godot-ci-font:latest \
             godot --headless --no-window --quit --install-templates
 
@@ -85,6 +86,7 @@ jobs:
           echo "Windows export start: $(date)"
           docker run --rm \
             -v "$PWD":/project \
+            -v godot-templates:/root/.local/share/godot \
             -w /project \
             godot-ci-font:latest \
             godot --headless --no-window /project/project.godot \
@@ -98,6 +100,7 @@ jobs:
           echo "Web export start: $(date)"
           docker run --rm \
             -v "$PWD":/project \
+            -v godot-templates:/root/.local/share/godot \
             -w /project \
             godot-ci-font:latest \
             godot --headless --no-window /project/project.godot \

--- a/.github/workflows/alpha_build_export.yml
+++ b/.github/workflows/alpha_build_export.yml
@@ -90,7 +90,6 @@ jobs:
             -w /project \
             godot-ci-font:latest \
             godot --headless --no-window /project/project.godot \
-            --skip-broken \
             --export-release "Windows Desktop" builds/windows/Alpha.exe
           echo "Windows export done: $(date)"
 
@@ -104,7 +103,6 @@ jobs:
             -w /project \
             godot-ci-font:latest \
             godot --headless --no-window /project/project.godot \
-            --skip-broken \
             --export-release "Web" builds/web/Alpha.html
           echo "Web export done: $(date)"
 

--- a/.github/workflows/alpha_build_export.yml
+++ b/.github/workflows/alpha_build_export.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   export_builds:
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --no-deprecation
 
     steps:
       - uses: actions/checkout@v4
@@ -86,6 +88,7 @@ jobs:
           echo "Windows export start: $(date)"
           docker run --rm \
             -v "$PWD":/project \
+            -v "$PWD/builds/windows:/project/builds/windows" \
             -v godot-templates:/root/.local/share/godot \
             -w /project \
             godot-ci-font:latest \
@@ -99,6 +102,7 @@ jobs:
           echo "Web export start: $(date)"
           docker run --rm \
             -v "$PWD":/project \
+            -v "$PWD/builds/web:/project/builds/web" \
             -v godot-templates:/root/.local/share/godot \
             -w /project \
             godot-ci-font:latest \

--- a/.github/workflows/alpha_build_export.yml
+++ b/.github/workflows/alpha_build_export.yml
@@ -62,7 +62,7 @@ jobs:
       # ✅ VERIFY IMAGE EXISTS (prevents your error)
       - name: Verify Docker Image Exists
         run: |
-          docker images | grep godot-ci-font || (echo "Image not built!" && exit 1)
+          docker inspect godot-ci-font:latest > /dev/null || (echo "Image godot-ci-font:latest not found!" && exit 1)
 
       # Move cache safely
       - name: Move Docker cache

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -1,124 +1,23 @@
 [preset.0]
 
-name="Web"
-platform="Web"
-runnable=true
-dedicated_server=false
-custom_features=""
-export_filter="all_resources"
-include_filter=""
-exclude_filter=""
-export_path="builds/web/Alpha.html"
-patches=PackedStringArray()
-patch_delta_encoding=false
-patch_delta_compression_level_zstd=19
-patch_delta_min_reduction=0.1
-patch_delta_include_filters="*"
-patch_delta_exclude_filters=""
-encryption_include_filters=""
-encryption_exclude_filters=""
-seed=0
-encrypt_pck=false
-encrypt_directory=false
-script_export_mode=2
-
-[preset.0.options]
-
-custom_template/debug=""
-custom_template/release=""
-variant/extensions_support=false
-variant/thread_support=false
-vram_texture_compression/for_desktop=true
-vram_texture_compression/for_mobile=false
-html/export_icon=true
-html/custom_html_shell=""
-html/head_include=""
-html/canvas_resize_policy=2
-html/focus_canvas_on_start=true
-html/experimental_virtual_keyboard=false
-progressive_web_app/enabled=false
-progressive_web_app/ensure_cross_origin_isolation_headers=true
-progressive_web_app/offline_page=""
-progressive_web_app/display=1
-progressive_web_app/orientation=0
-progressive_web_app/icon_144x144=""
-progressive_web_app/icon_180x180=""
-progressive_web_app/icon_512x512=""
-progressive_web_app/background_color=Color(0, 0, 0, 1)
-threads/emscripten_pool_size=8
-threads/godot_pool_size=4
-dotnet/include_scripts_content=false
-dotnet/include_debug_symbols=true
-dotnet/embed_build_outputs=false
-
-[preset.1]
-
 name="Windows Desktop"
 platform="Windows Desktop"
 runnable=true
-dedicated_server=false
-custom_features=""
 export_filter="all_resources"
-include_filter=""
-exclude_filter=""
 export_path="builds/windows/Alpha.exe"
-patches=PackedStringArray()
-patch_delta_encoding=false
-patch_delta_compression_level_zstd=19
-patch_delta_min_reduction=0.1
-patch_delta_include_filters="*"
-patch_delta_exclude_filters=""
-encryption_include_filters=""
-encryption_exclude_filters=""
-seed=0
-encrypt_pck=false
-encrypt_directory=false
-script_export_mode=2
+
+[preset.0.options]
+
+binary_format/architecture="x86_64"
+
+[preset.1]
+
+name="Web"
+platform="Web"
+runnable=true
+export_filter="all_resources"
+export_path="builds/web/Alpha.html"
 
 [preset.1.options]
 
-custom_template/debug=""
-custom_template/release=""
-debug/export_console_wrapper=1
-binary_format/embed_pck=false
-texture_format/s3tc_bptc=true
-texture_format/etc2_astc=false
-shader_baker/enabled=false
-binary_format/architecture="x86_64"
-codesign/enable=false
-codesign/timestamp=true
-codesign/timestamp_server_url=""
-codesign/digest_algorithm=1
-codesign/description=""
-codesign/custom_options=PackedStringArray()
-application/modify_resources=true
-application/icon=""
-application/console_wrapper_icon=""
-application/icon_interpolation=4
-application/file_version=""
-application/product_version=""
-application/company_name=""
-application/product_name=""
-application/file_description=""
-application/copyright=""
-application/trademarks=""
-application/export_angle=0
-application/export_d3d12=0
-application/d3d12_agility_sdk_multiarch=true
-ssh_remote_deploy/enabled=false
-ssh_remote_deploy/host="user@host_ip"
-ssh_remote_deploy/port="22"
-ssh_remote_deploy/extra_args_ssh=""
-ssh_remote_deploy/extra_args_scp=""
-ssh_remote_deploy/run_script="Expand-Archive -LiteralPath '{temp_dir}\\{archive_name}' -DestinationPath '{temp_dir}'
-$action = New-ScheduledTaskAction -Execute '{temp_dir}\\{exe_name}' -Argument '{cmd_args}'
-$trigger = New-ScheduledTaskTrigger -Once -At 00:00
-$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
-$task = New-ScheduledTask -Action $action -Trigger $trigger -Settings $settings
-Register-ScheduledTask godot_remote_debug -InputObject $task -Force:$true
-Start-ScheduledTask -TaskName godot_remote_debug
-while (Get-ScheduledTask -TaskName godot_remote_debug | ? State -eq running) { Start-Sleep -Milliseconds 100 }
-Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue"
-ssh_remote_deploy/cleanup_script="Stop-ScheduledTask -TaskName godot_remote_debug -ErrorAction:SilentlyContinue
-Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue
-Remove-Item -Recurse -Force '{temp_dir}'"
+html/export_icon=true

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -4,6 +4,8 @@ name="Windows Desktop"
 platform="Windows Desktop"
 runnable=true
 export_filter="all_resources"
+include_filter=""
+exclude_filter=""
 export_path="builds/windows/Alpha.exe"
 
 [preset.0.options]
@@ -16,6 +18,8 @@ name="Web"
 platform="Web"
 runnable=true
 export_filter="all_resources"
+include_filter=""
+exclude_filter=""
 export_path="builds/web/Alpha.html"
 
 [preset.1.options]

--- a/project.godot
+++ b/project.godot
@@ -20,10 +20,6 @@ window/size/viewport_width=1920
 window/size/viewport_height=1920
 window/stretch/mode="canvas_items"
 
-[dotnet]
-
-project/assembly_name="anino-visual-novel"
-
 [input]
 
 ui_accept={


### PR DESCRIPTION
## Description
Fixed CI pipeline failure where Docker image wasn't available during export, causing builds to fail with "Unable to find image" error.

**Project Configuration Changes:**
- Removed `[dotnet]` section from `project.godot` (switching from Mono to GDScript for Web export support)
- Simplified `export_presets.cfg` to minimal viable config with required keys

### Changes Made
- Build Docker image with `--load` flag
- Use `docker inspect` for reliable image verification (no false positives)
- Mount `godot-templates` volume to persist templates across containers
- Mount `builds/` directories for artifact persistence
- Add timing output for export progress tracking

## Related Issue
Closes #40

## Type of Change
- [x] fix: Bug fix
- [x] ci: CI/CD changes

## Testing
- ✅ Tested locally with docker buildx
- ✅ Windows and Web exports succeed
- ✅ Artifacts upload correctly
- ✅ No "Unable to find image" errors

## Checklist
- [x] My commit messages follow the Conventional Commits format
- [x] I have tested my changes in Godot
- [x] I have not broken any existing functionality