### PR TITLE
chore(ci/cd): migrate game assets to anino-assets submodule and enforce clean asset pipeline (web-only usage)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ Thumbs.db
 Dockerfile
 *.local
 .env.local
+
+assets/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "assets"]
+	path = assets
+	url = https://github.com/NoContextOrg/anino-assets.git
+	branch = main


### PR DESCRIPTION
## Description

This PR migrates the repository from locally tracked game assets to a centralized asset management system using the `anino-assets` Git submodule.

All previously tracked binary and game asset files have been removed from this repository and are now sourced externally from:

https://github.com/NoContextOrg/anino-assets

This change enforces a single source of truth for assets and aligns the project with a scalable multi-project asset pipeline.

Only the `web/` asset layer is actively used by this project, while the remaining asset categories exist in the upstream repository for organizational and future extensibility purposes.

---

## Related Issue

Closes #57

---

## Type of Change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation
- [ ] style: Code style (formatting, etc.)
- [x] refactor: Code refactoring
- [ ] perf: Performance improvement
- [ ] test: Adding/updating tests
- [x] chore: Build/tooling changes
- [x] ci: CI/CD changes

---

## Testing

- Verified clean repository state after `git rm --cached assets`
- Confirmed `anino-assets` submodule initializes correctly
- Validated clean clone workflow using:
  ```bash
  git clone --recurse-submodules
<img width="1252" height="962" alt="image" src="https://github.com/user-attachments/assets/01fc7352-a832-4f16-b4f1-8ce984bfd5c3" />