### PR TITLE
docs/23 update quick start and setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,89 @@
 # Contributing to Anino Visual Novel
 
-## Setup Local Development Environment
+This document complements `README.md` and defines contribution rules for code, assets, and pull requests.
 
-### Prerequisites
-- Node.js 16+ installed
-- Git installed
+## Requirements
 
-### Initial Setup
+- **Godot 4.6 (recommended)** (project declares `config/features` including `"4.6"`)
+- **Git** + **Git LFS** (mandatory)
 
-1. **Clone the repository**
+## Setup (Git LFS + project)
+
 ```bash
+# Enable LFS once per machine
+git lfs install
+
+# Clone + fetch LFS objects
 git clone https://github.com/NoContextOrg/anino-visual-novel.git
 cd anino-visual-novel
+
+git lfs pull
+```
+
+Open `project.godot` in Godot and run the project (F5).
+
+## Naming and folder rules (CI is case-sensitive)
+
+- Use **`snake_case`** and **lowercase** for all file/folder names
+- Keep folders **segregated by concern** (avoid dumping unrelated files in a root)
+
+Code conventions:
+
+- GDScript files: `snake_case.gd`
+- Classes: `PascalCase`
+- Variables/functions: `snake_case`
+- Constants: `SCREAMING_SNAKE_CASE`
+- Scene files: `snake_case.tscn`
+- Node names: `PascalCase`
+- Signals: `snake_case`
+
+## Source vs Godot-native
+
+- **Assets (LFS-backed)**: `res://assets/` (`.png`, `.jpg`, `.psd`, `.wav`, `.ogg`)
+- **Godot-native resources**: `res://resources/` (`.tres`, `.res`)
+
+### Asset organization (no messy roots)
+
+- Category first, then concern/usage (scene/feature/system)
+- Prefer concern foldering even for reusable assets (no generic `shared/` bucket)
+- If scene-specific, add `scene_*` under the concern when possible
+
+## Testing (mandatory before PR)
+
+This repo includes GUT in `res://addons/gut/`.
+
+1. Ensure the plugin is enabled: **Project → Project Settings → Plugins → GUT → On**
+2. Run all tests under `res://test/`
+
+## SOP: Before you push
+
+1. Follow naming/layout rules (case + `snake_case`)
+2. Run the project (F5)
+3. Run all GUT tests
+
+If you changed assets in `res://assets/`:
+
+- Open the project to generate/update imports
+- Commit `*.import` sidecar files
+- Commit `.import/` **if it is generated/present** in the repo
+
+LFS sanity checks:
+
+```bash
+git lfs pull
+git lfs status
+git lfs ls-files
+```
+
+## CI failures
+
+- Read logs in **GitHub → Actions** and search for `ERROR:`, `SCRIPT ERROR:`, `Parse Error:`
+- Common causes: case mismatches, missing/stale imports, broken paths after moves, committed LFS pointer files
+
+## Pull requests
+
+- Branch: `type/issue-id-description` (example: `docs/23-update-quick-start-and-setup-guide`)
+- Conventional Commits: `feat|fix|chore|docs(scope): description`
+- Follow `.github/pull_request_template.md`
+- Link issues in PR description: `Closes #<id>`
+- Ensure labels: `type:*`, `size:*`, `priority:*`

--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ This repository includes **GUT** under `res://addons/gut/` and it is enabled in 
 
 ---
 
+## 👥 Team Structure
+
+- **Project Manager**: Owns the GitHub Board, requirements, and sprint prioritization
+- **Architect / Tech Lead**: Defines core architecture and acts as the primary PR reviewer
+- **DevOps**: Manages CI/CD, Godot export templates, and automated builds
+- **Gameplay Programmers**: Implement mechanics, AI, and core game loops
+- **UI & Systems Programmers**: Build menus, save systems, and audio implementation
+
+---
+
+## 🛑 The Golden Rule: "One Dev, One Scene"
+
+Godot scene files (`.tscn`) are difficult to merge. To avoid corrupted files and merge conflicts:
+
+- **Communicate**: If you are editing a major shared scene (e.g., `Main.tscn`), tell the team
+- **Componentize**: Break large scenes into smaller, instanced `.tscn` files
+- **Test Locally**: Always run the game and your specific GUT tests before pushing code
+
+---
+
 ## 🧭 Project Rules (Read before touching files)
 
 ### 1) Naming + layout (CI is case-sensitive)
@@ -90,6 +110,74 @@ assets/
             ├── rooftop_sunset.jpg
             └── rooftop_night.jpg
 ```
+
+Example (per-concern foldering, like `assets/ui/map/...`):
+
+```text
+assets/
+└── ui/
+    ├── map/
+    │   ├── background_map.png
+    │   ├── chapter_1_button.png
+    │   └── chapter_2_button.png
+    └── loading/
+        └── load_spinner.png
+```
+
+---
+
+## 🔄 Development Workflow
+
+### 1) Branching & Commits
+
+- Create a branch for every issue:
+  - `type/issue-id-description` (e.g., `docs/23-update-quick-start-and-setup-guide`)
+- We use **Conventional Commits**:
+
+```text
+feat(scope): description
+fix(scope): description
+chore(scope): description
+docs(scope): description
+```
+
+### 2) Pull Requests
+
+- Open a PR against `main`
+- Link the issue (e.g., `Closes #23`)
+- Ensure the issue has proper labels:
+  - `type:*`
+  - `size:*`
+  - `priority:*`
+- Request a review from the Architect
+- **Squash and Merge** once approved and CI checks pass
+
+---
+
+## 📄 PR Template Requirement
+
+All pull requests must follow `.github/pull_request_template.md`.
+
+**Related Issue**
+
+```text
+Closes #
+```
+
+**Type of Change** *(must match issue label)*
+
+- `feat`: New feature (`type: feature`)
+- `fix`: Bug fix (`type: bug`)
+- `chore`: Tooling/refactor (`type: chore`)
+- `docs`: Documentation (`type: docs`)
+
+**Testing & Checklist**
+
+- My commit messages follow the Conventional Commits format
+- I have tested my changes in Godot
+- I have run GUT tests locally before pushing
+- I have updated documentation if needed
+- I have not broken any existing functionality
 
 ---
 
@@ -169,47 +257,57 @@ head -n 5 assets/path/to/suspicious_file
 
 ---
 
-## 🔄 Development Workflow
+## 🧷 Git LFS Push Failures (GH008) — What it means and how to fix it
 
-### Branching & commits
+If you see this during `git push`:
 
-- Branches: `type/issue-id-short-description`
-  - Example: `feature/101-dialogue-skipping`
-- Conventional Commits:
+- `remote: error: GH008: Your push referenced at least 1 unknown Git LFS object`
 
-```text
-feat(scope): description
-fix(scope): description
-chore(scope): description
-docs(scope): description
+It means your commit references an LFS object that **was not uploaded** to GitHub’s LFS storage yet.
+
+### Hooks note (this repo uses Husky)
+
+This repo uses Husky (`core.hooksPath=.husky/_`). The LFS pre-push hook lives at:
+
+- `.husky/_/pre-push`
+
+So you won’t see it under `.git/hooks/pre-push`.
+
+### Fix steps
+
+```bash
+# Ensure the LFS hook is correctly installed/updated (safe to run)
+git lfs update --force
+
+# Upload all LFS objects required by your branch
+git lfs push --all origin <your-branch>
+
+# Retry the normal push
+git push -u origin <your-branch>
 ```
 
-### Pull Requests
+### If it says your local objects are missing/corrupt
 
-- Open a PR against `main`
-- Link the issue (e.g., `Closes #101`)
-- Ensure the issue has labels: `type:*`, `size:*`, `priority:*`
-- Request a review from the Architect
-- **Squash and Merge** once approved and CI checks pass
+Repair your local LFS cache, then retry:
 
----
-
-## 🛑 The Golden Rule: "One Dev, One Scene"
-
-Godot scene files (`.tscn`) are difficult to merge. To avoid corrupted files and merge conflicts:
-
-- Communicate if you are editing a shared scene
-- Componentize large scenes into smaller instanced scenes
+```bash
+git lfs fetch --all origin
+git lfs fsck
+git lfs checkout
+```
 
 ---
 
-## 👥 Team Structure
+## 📅 Weekly Development Timeline
 
-- **Project Manager**: Owns the GitHub Board, requirements, and sprint prioritization
-- **Architect / Tech Lead**: Defines core architecture and acts as the primary PR reviewer
-- **DevOps**: Manages CI/CD, Godot export templates, and automated builds
-- **Gameplay Programmers**: Implement mechanics, AI, and core game loops
-- **UI & Systems Programmers**: Build menus, save systems, and audio implementation
+- **Sunday — Task Assignment & Kickoff**
+  - Stand-up meeting to distribute tasks; work can start immediately after
+- **Wednesday — Progress Review (Project Manager)**
+  - Review progress and unblock issues
+- **Friday — Build Review (Technical Lead)**
+  - Evaluate the current build and request improvements
+- **Saturday & Sunday — DevOps Review & Evaluation**
+  - Integration checks, testing, and deployment readiness evaluation
 
 ---
 
@@ -218,10 +316,98 @@ Godot scene files (`.tscn`) are difficult to merge. To avoid corrupted files and
 ```text
 res://
 ├── assets/               # LFS-backed binaries (png/jpg/psd/wav/ogg)
-├── builds/               # Export outputs (web/windows)
 ├── resources/            # Godot-native resources (.tres/.res)
-├── scenes/               # .tscn (UI/system/templates)
+├── scenes/               # .tscn (ui/system/templates)
 ├── src/                  # GDScript (autoload/gameplay/ui)
 ├── story/                # Narrative data (JSON/text/markdown)
-└── addons/               # Editor plugins (GUT, etc.)
+├── addons/               # Editor plugins (GUT, etc.)
+└── builds/               # Export outputs (web/windows) (not committed)
 ```
+
+---
+
+## 📂 res://assets/ (Managed via Git LFS)
+
+**Primary Owner:** DevOps
+**Contributors:** Art & Sound Teams
+
+**Role:** Ensures `.gitattributes` tracks large files so the repo stays lean.
+
+- `characters/` *(DevOps / Art)*: high-resolution character sprites
+- `background/` *(DevOps / Art)*: large environment files
+- `music/` + `sfx/` *(DevOps / Sound)*: `.ogg` and `.wav`
+
+---
+
+## 📂 res://scenes/ (The "Assembly Line")
+
+**Primary Owner:** UI & Systems Programmers & Gameplay Programmer
+
+- `ui/` *(UI & Systems Programmers)*: menus and HUD `.tscn`
+- `system/` *(Gameplay Programmer)*: invisible scenes (audio/save/transition)
+- `templates/` *(Game Designer / Gameplay Programmer)*: chapter templates
+
+---
+
+## 📂 res://src/ (The "Engine Room")
+
+**Primary Owner:** Gameplay Programmer
+
+- `ui/` *(UI & Systems Programmers)*: menu logic scripts
+- `gameplay/` *(Gameplay Programmer)*: core systems (e.g., dialogue)
+- `autoload/` *(DevOps / Gameplay Programmer)*: global singletons
+
+---
+
+## 📂 res://story/ & res://resources/ (The "Database")
+
+**Primary Owner:** Gameplay Programmer
+
+- `story/`: dialogue, branching logic, narrative data (JSON/text)
+- `resources/`: `.tres` bridges referencing assets (e.g., characters, themes)
+
+---
+
+## 📊 Ownership & Tech Stack
+
+| Folder        | Primary Dev              | Tech Stack                |
+| ------------- | ------------------------ | ------------------------- |
+| `assets/`     | DevOps                   | Git LFS, `.png`, `.ogg`   |
+| `scenes/ui/`  | UI & Systems Programmers | Godot Nodes, `.tscn`      |
+| `src/ui/`     | UI & Systems Programmers | GDScript (UI logic)       |
+| `src/gameplay/` | Gameplay Programmer    | GDScript (system logic)   |
+| `src/autoload/` | Gameplay Programmer    | Singletons / global state |
+| `story/`      | Gameplay Programmer      | JSON / Text / Markdown    |
+
+---
+
+## 🏷️ Label Legend
+
+Every issue should have one label from each of the first three categories.
+
+### 1) Type (What is it?)
+
+- `type: bug` – Something is broken
+- `type: feature` – New mechanics or content
+- `type: chore` – Tooling or refactoring
+- `type: docs` – Documentation updates
+
+### 2) Size (How long?)
+
+- `size: S` – 1–2 hours
+- `size: M` – 1–3 days
+- `size: L` – Full sprint
+
+### 3) Priority (When?)
+
+- `priority: high` – Critical blockers or must-haves
+- `priority: med` – Standard sprint work
+- `priority: low` – Polish and minor tweaks
+
+### 4) Status (Where is it?)
+
+- `status: in-progress` – Active development
+- `status: blocked` – Technical or tool-related hard stop
+- `status: needs-info` – Waiting on a decision, art asset, or PM
+- `status: in-review` – Finished; waiting for Architect approval
+- `status: revision` – Changes requested by reviewer; high priority

--- a/README.md
+++ b/README.md
@@ -4,42 +4,193 @@ Welcome to the team! This document outlines our development workflow, our 8-pers
 
 ---
 
-## 🚀 Quick-Start & Setup
+## 🚀 Quick Start (Godot + Git LFS)
 
-We use **Git Large File Storage (LFS)** for all visual novel assets (PNG, PSD, WAV, OGG). You must have LFS installed to pull the art and audio correctly.
+We use **Git Large File Storage (LFS)** for visual novel assets (e.g. PNG, PSD, WAV, OGG). **You must initialize LFS locally** or you may end up with pointer files instead of real assets.
 
-### 1. Installation
+### Requirements
 
-Ensure you have **Godot 4.x** and **Git LFS** installed.
+- **Godot 4.6 (recommended)**
+  - This project declares `config/features` including `"4.6"` in `project.godot`.
+- **Git** and **Git LFS**
+
+### 1) Clone + Git LFS (mandatory)
 
 ```bash
-# Initialize Git LFS on your machine (only needs to be done once)
+# Enable Git LFS once per machine
 git lfs install
 
-# Clone the repository
+# Clone the repo
 git clone <your-repo-url>
 cd <your-repo-name>
 
-# Explicitly pull the large files
+# Fetch LFS objects
 git lfs pull
+
+# Optional sanity checks
+git lfs env
+git lfs ls-files
 ```
 
-### 2. Running the Game
+### 2) Open the project in Godot
 
-1. Open the Godot Project Manager
-2. Click **Import** and select the `project.godot` file
+1. Open **Godot Project Manager**
+2. Click **Import** and select `project.godot`
 3. Click **Import & Edit**
-4. Press **F5** to run the project
+4. Press **F5** to run
+
+### 3) Test framework (GUT) setup
+
+This repository includes **GUT** under `res://addons/gut/` and it is enabled in `project.godot`.
+
+1. Open **Project → Project Settings → Plugins**
+2. Ensure **GUT** is enabled
+3. Confirm tests exist under `res://test/`
 
 ---
 
-## 👥 Team Structure
+## 🧭 Project Rules (Read before touching files)
 
-* **Project Manager**: Owns the GitHub Board, requirements, and sprint prioritization
-* **Architect / Tech Lead**: Defines core architecture and acts as the primary PR reviewer
-* **DevOps**: Manages CI/CD, Godot export templates, and automated builds
-* **Gameplay Programmers**: Implement mechanics, AI, and core game loops
-* **UI & Systems Programmers**: Build menus, save systems, and audio implementation
+### 1) Naming + layout (CI is case-sensitive)
+
+- Use **`snake_case`** and **lowercase** for **all file/folder names**
+- Keep folders **segregated by concern**; don’t create “misc” buckets
+  - Example pattern: `assets/ui/map/...` instead of mixing map files into generic `assets/ui/`
+
+Code style:
+
+- GDScript files: `snake_case.gd`
+- Classes: `PascalCase`
+- Variables/functions: `snake_case`
+- Constants: `SCREAMING_SNAKE_CASE`
+- Scene files: `snake_case.tscn`
+- Node names: `PascalCase`
+- Signals: `snake_case`
+
+### 2) Source vs Godot-native
+
+- **Source assets (LFS)** → `res://assets/`
+  - `.png`, `.jpg`, `.psd`, `.wav`, `.ogg`
+- **Godot-native data** → `res://resources/`
+  - `.tres`, `.res`, themes
+
+### 3) Asset organization directive (no messy roots)
+
+- Organize assets by **category first** (what it is), then by **concern/usage** (where/how it’s used)
+- Prefer **concern foldering even for reusable assets** (no generic `shared/` bucket)
+- If an asset is scene-specific, add a scene folder under the concern (when possible)
+
+Example (matches current repo categories):
+
+```text
+assets/
+└── background/
+    └── chapter_1/
+        └── scene_1/
+            ├── rooftop_sunset.jpg
+            └── rooftop_night.jpg
+```
+
+---
+
+## 📦 SOP: Before You Push
+
+### A) Always (code or assets)
+
+1. Naming/layout rules followed (especially case + `snake_case`)
+2. Open Godot and ensure the project runs (F5)
+3. Run all GUT tests (see below)
+
+### B) If you changed assets in `res://assets/`
+
+1. Confirm LFS is active:
+
+```bash
+git lfs install
+```
+
+2. Open the project once in Godot to generate/update imports
+3. Verify LFS + avoid pointer files:
+
+```bash
+git lfs pull
+
+git lfs status
+
+git lfs ls-files
+
+# Pointer files are small text files starting with:
+# "version https://git-lfs.github.com/spec/v1"
+head -n 5 assets/path/to/suspicious_file
+```
+
+4. Import artifacts policy (required for CI):
+
+- Commit all `*.import` sidecar files.
+- Commit the `.import/` directory **if it is generated/present** in the repo.
+
+### C) If you moved/renamed anything
+
+1. Ensure references were updated in `.tscn` / `.tres`
+2. Re-run GUT tests
+
+---
+
+## ✅ Automated Tests (GUT)
+
+### Run locally (mandatory before PR)
+
+1. Enable the plugin: **Project Settings → Plugins → GUT → On**
+2. Open the GUT UI (from the GUT panel)
+3. Run all tests in `res://test/`
+
+---
+
+## 🧪 When CI / Automated Tests Fail (PR Protocol)
+
+### 1) How to read CI logs
+
+1. Open the failed workflow in **GitHub → Actions** for your PR
+2. Click the failed run, then open the failing job/step
+3. Search within logs for:
+
+- `ERROR:`
+- `SCRIPT ERROR:`
+- `Parse Error:`
+- `Failed loading resource`
+- `Could not open`
+
+### 2) Common failure causes (fix these first)
+
+- **Case / naming mismatch**: works locally, fails on Linux CI
+- **Missing/stale imports**: `.import/` or `*.import` not committed after new/moved assets
+- **Broken paths after moves**: `.tscn` / `.tres` still pointing to old locations
+- **LFS pointer committed**: asset file is actually a small text pointer
+
+---
+
+## 🔄 Development Workflow
+
+### Branching & commits
+
+- Branches: `type/issue-id-short-description`
+  - Example: `feature/101-dialogue-skipping`
+- Conventional Commits:
+
+```text
+feat(scope): description
+fix(scope): description
+chore(scope): description
+docs(scope): description
+```
+
+### Pull Requests
+
+- Open a PR against `main`
+- Link the issue (e.g., `Closes #101`)
+- Ensure the issue has labels: `type:*`, `size:*`, `priority:*`
+- Request a review from the Architect
+- **Squash and Merge** once approved and CI checks pass
 
 ---
 
@@ -47,240 +198,30 @@ git lfs pull
 
 Godot scene files (`.tscn`) are difficult to merge. To avoid corrupted files and merge conflicts:
 
-* **Communicate**: If you are editing a major shared scene (e.g., `Main.tscn`), tell the team
-* **Componentize**: Break large scenes into smaller, instanced `.tscn` files
-* **Test Locally**: Always run the game and your specific GUT tests before pushing code
-
-Here’s the final cleaned version with the **Label Legend section removed**:
+- Communicate if you are editing a shared scene
+- Componentize large scenes into smaller instanced scenes
 
 ---
 
-## 🔄 Development Workflow
+## 👥 Team Structure
 
-### 1. Branching & Commits
-
-* Create a branch for every issue:
-  `type/issue-id-description`
-  *(e.g., `feature/101-player-dash`)*
-
-* We use **Conventional Commits**, with the following allowed types:
-
-```text id="58214"
-feat(scope): description
-fix(scope): description
-chore(scope): description
-docs(scope): description
-```
-
----
-
-### 2. Pull Requests
-
-* Open a PR against `main`
-* Link the issue (e.g., `Closes #101`)
-* Ensure the issue has proper labels:
-
-  * `type:*`
-  * `size:*`
-  * `priority:*`
-* Request a review from the Architect
-* **Squash and Merge** once approved and CI checks pass
-
----
-
-### 📄 PR Template Requirement
-
-All pull requests must follow `.github/pull_request_template.md`:
-
-#### **Related Issue**
-
-```id="x91kd3"
-Closes #
-```
-
-#### **Type of Change** *(must match issue label)*
-
-* feat: New feature (`type: feature`)
-* fix: Bug fix (`type: bug`)
-* chore: Tooling/refactor (`type: chore`)
-* docs: Documentation (`type: docs`)
-
----
-
-### **Testing & Checklist**
-
-* My commit messages follow the Conventional Commits format
-* I have tested my changes in Godot
-* I have updated documentation if needed
-* I have not broken any existing functionality
-
----
-
-## 📅 Weekly Development Timeline
-
-### **Sunday — Task Assignment & Kickoff**
-
-A stand-up meeting is conducted to distribute and explain tasks for the week.
-Team members may begin working on their assigned responsibilities immediately after the meeting.
-
----
-
-### **Wednesday — Progress Review (Project Manager)**
-
-The Project Manager reviews task progress, identifies any blockers or risks, and provides guidance or adjustments as needed.
-
----
-
-### **Friday — Build Review (Technical Lead)**
-
-The Technical Lead evaluates the current build, assesses completed features, and provides technical feedback and required improvements.
-
----
-
-### **Saturday & Sunday — DevOps Review & Evaluation**
-
-The DevOps team reviews system integration, conducts testing, and evaluates deployment readiness and performance.
+- **Project Manager**: Owns the GitHub Board, requirements, and sprint prioritization
+- **Architect / Tech Lead**: Defines core architecture and acts as the primary PR reviewer
+- **DevOps**: Manages CI/CD, Godot export templates, and automated builds
+- **Gameplay Programmers**: Implement mechanics, AI, and core game loops
+- **UI & Systems Programmers**: Build menus, save systems, and audio implementation
 
 ---
 
 ## 📁 Project Architecture
 
-```text id="9f4a21"
+```text
 res://
-├── assets/
-│   ├── characters/       # Subfolders for each NPC (sprites, expressions)
-│   ├── backgrounds/      # Organized by location
-│   ├── music/
-│   └── sfx/
-├── scenes/
-│   ├── ui/               # Main Menu, Dialogue Box, Settings (UI Team)
-│   ├── system/           # Save/Load, Scene Manager, Audio Manager
-│   └── templates/        # Master scene for a "Chapter"
-├── src/                  # The GDScript logic
-│   ├── ui/               # Scripts for UI components
-│   ├── gameplay/         # Dialogue parser, Choice handlers
-│   └── autoload/         # Globals (GameManager.gd, EventBus.gd)
-├── story/
-│   ├── chapter_1/        # JSON/Resource/Dialogue files
-│   ├── chapter_2/
-│   └── ...
-└── resources/            # Custom .tres files (Character profiles, Theme files)
-└── addons/               # GUT test files
+├── assets/               # LFS-backed binaries (png/jpg/psd/wav/ogg)
+├── builds/               # Export outputs (web/windows)
+├── resources/            # Godot-native resources (.tres/.res)
+├── scenes/               # .tscn (UI/system/templates)
+├── src/                  # GDScript (autoload/gameplay/ui)
+├── story/                # Narrative data (JSON/text/markdown)
+└── addons/               # Editor plugins (GUT, etc.)
 ```
-
----
-
-## 📂 res://assets/ (Managed via Git LFS)
-
-**Primary Owner:** DevOps
-**Contributors:** Art & Sound Teams
-
-**Role:** Ensures `.gitattributes` tracks large files so the repo stays lean.
-
-* **characters/** *(DevOps / Art)*
-  High-resolution character sprites. DevOps manages LFS locking to prevent conflicts on `.psd` or `.png` files.
-
-* **backgrounds/** *(DevOps / Art)*
-  Large environment files, organized by `location_time` (e.g., `rooftop_sunset.png`).
-
-* **music/** & **sfx/** *(DevOps / Sound)*
-  All `.ogg` and `.wav` files. DevOps monitors LFS bandwidth for efficient access.
-
----
-
-## 📂 res://scenes/ (The "Assembly Line")
-
-**Primary Owner:** UI & Systems Programmers & Gameplay Programmer
-
-* **ui/** *(UI & Systems Programmers)*
-  `.tscn` files for HUD, Settings, and Save/Load screens.
-
-* **system/** *(Gameplay Programmer)*
-  “Invisible” scenes like `AudioPlayer`, `SaveEngine`, and `TransitionFader`.
-
-* **templates/** *(Game Designer / Gameplay Programmer)*
-  Master story scene combining Background + Character + Dialogue UI.
-
----
-
-## 📂 res://src/ (The "Engine Room")
-
-**Primary Owner:** Gameplay Programmer
-
-* **ui/** *(UI & Systems Programmers)*
-  Menu logic (e.g., `MainMenu.gd` handles button signals).
-
-* **gameplay/** *(Gameplay Programmer)*
-  Core systems. `DialogueParser.gd` is critical for the Alpha build.
-
-* **autoload/** *(DevOps / Gameplay Programmer)*
-  Globals like `GameState.gd`. These singletons must be stable and well-documented.
-
----
-
-## 📂 res://story/ & res://resources/ (The "Database")
-
-**Primary Owner:** Gameplay Programmer 
-
-* **chapter_1/** to **chapter_5/**
-  Dialogue, branching logic, and narrative data (JSON/text). Not LFS-tracked for fast iteration.
-
-* **story role:**
-  Defines narrative flow, choices, pacing, and structure used by the gameplay systems.
-
-* **resources/**
-  `.tres` files acting as bridges (e.g., `Character.tres` referencing assets in `assets/characters/`).
-
----
-
-## 📊 Ownership & Tech Stack
-
-| Folder        | Primary Dev                         | Tech Stack                |
-| ------------- | ----------------------------------- | ------------------------- |
-| assets/       | DevOps                              | Git LFS, `.png`, `.ogg`   |
-| scenes/ui/    | UI & Systems Programmers            | Godot Nodes, `.tscn`      |
-| src/ui/       | UI & Systems Programmers            | GDScript (Visual Logic)   |
-| src/gameplay/ | Gameplay Programmer                 | GDScript (System Logic)   |
-| src/autoload/ | Gameplay Programmer                 | Singletons / Global State |
-| story/        | Gameplay Programmer                 | JSON / Text / Markdown    |
-
----
-
-## 🏷️ Label Legend
-
-Every issue should have one label from each of the first three categories.
-
-### 1. Type (What is it?)
-
-* `type: bug` – Something is broken
-* `type: feature` – New mechanics or content
-* `type: chore` – Tooling or refactoring
-* `type: docs` – Documentation updates
-
----
-
-### 2. Size (How long?)
-
-* `size: S` – 1–2 hours
-* `size: M` – 1–3 days
-* `size: L` – Full sprint
-
----
-
-### 3. Priority (When?)
-
-* `priority: high` – Critical blockers or must-haves
-* `priority: med` – Standard sprint work
-* `priority: low` – Polish and minor tweaks
-
----
-
-### 4. Status (Where is it?)
-
-* `status: in-progress` – Active development
-* `status: blocked` – Technical or tool-related hard stop
-* `status: needs-info` – Waiting on a decision, art asset, or PM
-* `status: in-review` – Finished; waiting for Architect approval
-* `status: revision` – Changes requested by reviewer; high priority
-
----

--- a/assets/background/green-pasteur-grass-field-illustration-anime-manga-visual-novel-background-wallpaper-photo (1).jpg.import
+++ b/assets/background/green-pasteur-grass-field-illustration-anime-manga-visual-novel-background-wallpaper-photo (1).jpg.import
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:213193c073f1dabd81dd3ad9ce9e43be229caf6af6cc56cfb9809a3716ac9301
-size 1203
+oid sha256:4705f101f02ca145d5879f846656319d95055286ab8b602ab7a72a0f4ef91beb
+size 841


### PR DESCRIPTION
## Description
Updates project documentation to reflect the current LFS-backed folder architecture and establishes a clear, enforceable protocol for PRs when tests/CI fail.

Key updates:
- Quick Start updated for Godot 4.6 and mandatory Git LFS initialization/pull
- GUT setup and local test-running steps documented
- Naming + folder segregation rules (snake_case, case-sensitive CI) documented
- Asset organization standards (category → concern → scene when possible) with examples (including `assets/ui/map/...`)
- SOP before pushing (assets/code), pointer-file checks, and import policy (`*.import`, `.import/` if present)
- CI log reading + common failure causes section added
- GH008 Git LFS push failure explanation + Husky hook location and remediation steps
- Restored and aligned workflow sections (team structure, PR/labels, timeline, architecture)

## Related Issue
Closes #23

## Type of Change
- [ ] feat: New feature
- [ ] fix: Bug fix
- [x] docs: Documentation
- [ ] style: Code style (formatting, etc.)
- [ ] refactor: Code refactoring
- [ ] perf: Performance improvement
- [ ] test: Adding/updating tests
- [ ] chore: Build/tooling changes
- [ ] ci: CI/CD changes

## Testing
- Verified `README.md` and `CONTRIBUTING.md` formatting renders correctly on GitHub (headers, lists, code blocks).
- Confirmed Godot version guidance matches `project.godot` (`config/features` includes `"4.6"`).
- Confirmed `.import/` is not currently present in-repo; documentation reflects “commit if generated/present”.

## Checklist
- [x] My commit messages follow the Conventional Commits format
- [ ] I have tested my changes in Godot
- [x] I have updated documentation if needed
- [x] I have not broken any existing functionality