### PR TITLE
feat(ui): revamp main menu and load game UI with new assets

### DIFF
--- a/scenes/ui/load_game.tscn
+++ b/scenes/ui/load_game.tscn
@@ -1,0 +1,239 @@
+[gd_scene format=3]
+
+[ext_resource type="Theme" path="res://resources/default_theme.tres" id="1"]
+[ext_resource type="Script" path="res://src/ui/load_game.gd" id="2"]
+[ext_resource type="FontFile" path="res://resources/fonts/Montserrat-Italic-VariableFont_wght.ttf" id="3"]
+
+[sub_resource type="StyleBoxFlat" id="1"]
+bg_color = Color(0.12, 0.08, 0.05, 0.95)
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.6, 0.45, 0.2, 1)
+
+[node name="LoadGame" type="Control"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1")
+script = ExtResource("2")
+
+[node name="Overlay" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.05, 0.03, 0.02, 0.92)
+
+[node name="Title" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 0
+anchor_left = 0.5
+anchor_top = 0.0
+anchor_right = 0.5
+anchor_bottom = 0.0
+offset_left = -300.0
+offset_top = 40.0
+offset_right = 300.0
+offset_bottom = 140.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "Load Game"
+horizontal_alignment = 1
+vertical_alignment = 1
+theme_override_fonts/font = ExtResource("3")
+theme_override_font_sizes/font_size = 72
+theme_override_colors/font_color = Color(0.9, 0.75, 0.4, 1)
+
+[node name="CenterContainer" type="CenterContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="SlotList" type="VBoxContainer" parent="CenterContainer"]
+layout_mode = 2
+theme_override_constants/separation = 24
+
+[node name="Slot1" type="PanelContainer" parent="CenterContainer/SlotList"]
+layout_mode = 2
+custom_minimum_size = Vector2(700, 140)
+theme_override_styles/panel = SubResource("1")
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 16
+
+[node name="SlotHBox1" type="HBoxContainer" parent="CenterContainer/SlotList/Slot1"]
+layout_mode = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer/SlotList/Slot1/SlotHBox1"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="SlotLabel1" type="Label" parent="CenterContainer/SlotList/Slot1/SlotHBox1/VBoxContainer"]
+layout_mode = 2
+text = "Slot 1"
+theme_override_fonts/font = ExtResource("3")
+theme_override_font_sizes/font_size = 36
+theme_override_colors/font_color = Color(0.9, 0.75, 0.4, 1)
+
+[node name="SaveInfo1" type="Label" parent="CenterContainer/SlotList/Slot1/SlotHBox1/VBoxContainer"]
+layout_mode = 2
+text = "— Empty —"
+theme_override_fonts/font = ExtResource("3")
+theme_override_font_sizes/font_size = 24
+theme_override_colors/font_color = Color(0.6, 0.55, 0.5, 1)
+
+[node name="ButtonsHBox" type="HBoxContainer" parent="CenterContainer/SlotList/Slot1/SlotHBox1"]
+layout_mode = 2
+size_flags_horizontal = 0
+alignment = 2
+
+[node name="LoadBtn1" type="Button" parent="CenterContainer/SlotList/Slot1/SlotHBox1/ButtonsHBox"]
+layout_mode = 2
+text = "Load"
+flat = true
+theme_override_fonts/font = ExtResource("3")
+theme_override_font_sizes/font_size = 28
+theme_override_colors/font_color = Color(0.9, 0.75, 0.4, 1)
+
+[node name="DeleteBtn1" type="Button" parent="CenterContainer/SlotList/Slot1/SlotHBox1/ButtonsHBox"]
+layout_mode = 2
+text = "Delete"
+flat = true
+theme_override_fonts/font = ExtResource("3")
+theme_override_font_sizes/font_size = 28
+theme_override_colors/font_color = Color(0.8, 0.3, 0.2, 1)
+
+[node name="Slot2" type="PanelContainer" parent="CenterContainer/SlotList"]
+layout_mode = 2
+custom_minimum_size = Vector2(700, 140)
+theme_override_styles/panel = SubResource("1")
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 16
+
+[node name="SlotHBox2" type="HBoxContainer" parent="CenterContainer/SlotList/Slot2"]
+layout_mode = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer/SlotList/Slot2/SlotHBox2"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="SlotLabel2" type="Label" parent="CenterContainer/SlotList/Slot2/SlotHBox2/VBoxContainer"]
+layout_mode = 2
+text = "Slot 2"
+theme_override_fonts/font = ExtResource("3")
+theme_override_font_sizes/font_size = 36
+theme_override_colors/font_color = Color(0.9, 0.75, 0.4, 1)
+
+[node name="SaveInfo2" type="Label" parent="CenterContainer/SlotList/Slot2/SlotHBox2/VBoxContainer"]
+layout_mode = 2
+text = "— Empty —"
+theme_override_fonts/font = ExtResource("3")
+theme_override_font_sizes/font_size = 24
+theme_override_colors/font_color = Color(0.6, 0.55, 0.5, 1)
+
+[node name="ButtonsHBox" type="HBoxContainer" parent="CenterContainer/SlotList/Slot2/SlotHBox2"]
+layout_mode = 2
+size_flags_horizontal = 0
+alignment = 2
+
+[node name="LoadBtn2" type="Button" parent="CenterContainer/SlotList/Slot2/SlotHBox2/ButtonsHBox"]
+layout_mode = 2
+text = "Load"
+flat = true
+theme_override_fonts/font = ExtResource("3")
+theme_override_font_sizes/font_size = 28
+theme_override_colors/font_color = Color(0.9, 0.75, 0.4, 1)
+
+[node name="DeleteBtn2" type="Button" parent="CenterContainer/SlotList/Slot2/SlotHBox2/ButtonsHBox"]
+layout_mode = 2
+text = "Delete"
+flat = true
+theme_override_fonts/font = ExtResource("3")
+theme_override_font_sizes/font_size = 28
+theme_override_colors/font_color = Color(0.8, 0.3, 0.2, 1)
+
+[node name="Slot3" type="PanelContainer" parent="CenterContainer/SlotList"]
+layout_mode = 2
+custom_minimum_size = Vector2(700, 140)
+theme_override_styles/panel = SubResource("1")
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 16
+
+[node name="SlotHBox3" type="HBoxContainer" parent="CenterContainer/SlotList/Slot3"]
+layout_mode = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer/SlotList/Slot3/SlotHBox3"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="SlotLabel3" type="Label" parent="CenterContainer/SlotList/Slot3/SlotHBox3/VBoxContainer"]
+layout_mode = 2
+text = "Slot 3"
+theme_override_fonts/font = ExtResource("3")
+theme_override_font_sizes/font_size = 36
+theme_override_colors/font_color = Color(0.9, 0.75, 0.4, 1)
+
+[node name="SaveInfo3" type="Label" parent="CenterContainer/SlotList/Slot3/SlotHBox3/VBoxContainer"]
+layout_mode = 2
+text = "— Empty —"
+theme_override_fonts/font = ExtResource("3")
+theme_override_font_sizes/font_size = 24
+theme_override_colors/font_color = Color(0.6, 0.55, 0.5, 1)
+
+[node name="ButtonsHBox" type="HBoxContainer" parent="CenterContainer/SlotList/Slot3/SlotHBox3"]
+layout_mode = 2
+size_flags_horizontal = 0
+alignment = 2
+
+[node name="LoadBtn3" type="Button" parent="CenterContainer/SlotList/Slot3/SlotHBox3/ButtonsHBox"]
+layout_mode = 2
+text = "Load"
+flat = true
+theme_override_fonts/font = ExtResource("3")
+theme_override_font_sizes/font_size = 28
+theme_override_colors/font_color = Color(0.9, 0.75, 0.4, 1)
+
+[node name="DeleteBtn3" type="Button" parent="CenterContainer/SlotList/Slot3/SlotHBox3/ButtonsHBox"]
+layout_mode = 2
+text = "Delete"
+flat = true
+theme_override_fonts/font = ExtResource("3")
+theme_override_font_sizes/font_size = 28
+theme_override_colors/font_color = Color(0.8, 0.3, 0.2, 1)
+
+[node name="BackButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 0
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -80.0
+offset_top = -80.0
+offset_right = 80.0
+offset_bottom = -20.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "← Back"
+flat = true
+theme_override_fonts/font = ExtResource("3")
+theme_override_font_sizes/font_size = 36
+theme_override_colors/font_color = Color(0.9, 0.75, 0.4, 1)

--- a/scenes/ui/main_menu.tscn
+++ b/scenes/ui/main_menu.tscn
@@ -1,22 +1,42 @@
 [gd_scene format=3 uid="uid://dkkie03nslxcp"]
 
 [ext_resource type="Theme" uid="uid://dwjpijsc3chou" path="res://resources/default_theme.tres" id="1_m1kxf"]
-[ext_resource type="Script" uid="uid://xbkdo6ke4nwg" path="res://src/ui/main_menu.gd" id="1_x2yvf"]
-[ext_resource type="Texture2D" uid="uid://3ecxjs3m85k0" path="res://assets/background/green-pasteur-grass-field-illustration-anime-manga-visual-novel-background-wallpaper-photo (1).jpg" id="2_uhagc"]
+[ext_resource type="Script" uid="uid://dtm7fyxorme7h" path="res://src/ui/main_menu.gd" id="1_x2yvf"]
+[ext_resource type="Texture2D" uid="uid://b7dykl7wqwbr1" path="res://assets/main_menu/background/burning_mountain_1.png" id="bg_1"]
+[ext_resource type="Texture2D" uid="uid://oqskxt6nksox" path="res://assets/main_menu/background/burning_mountain_2.png" id="bg_2"]
+[ext_resource type="Texture2D" uid="uid://ch68mg05did1k" path="res://assets/main_menu/background/burning_mountain_3.png" id="bg_3"]
+[ext_resource type="Texture2D" uid="uid://c4jdm2v3pbt36" path="res://assets/main_menu/background/burning_mountain_4.png" id="bg_4"]
+[ext_resource type="Texture2D" uid="uid://mpa4lrkv2bru" path="res://assets/main_menu/background/burning_mountain_5.png" id="bg_5"]
+[ext_resource type="Texture2D" uid="uid://ckamqrqip4ify" path="res://assets/main_menu/background/burning_mountain_6.png" id="bg_6"]
+[ext_resource type="Texture2D" uid="uid://bol3uyegavbs3" path="res://assets/main_menu/background/burning_mountain_7.png" id="bg_7"]
+[ext_resource type="Texture2D" uid="uid://djshhsi6pmof1" path="res://assets/main_menu/buttons/load_btn.png" id="btn_load"]
+[ext_resource type="Texture2D" uid="uid://cmyavwed8crvq" path="res://assets/main_menu/buttons/play_btn.png" id="btn_play"]
+[ext_resource type="Texture2D" uid="uid://djvu1dicm06hv" path="res://assets/main_menu/buttons/quit_btn.png" id="btn_quit"]
+[ext_resource type="Texture2D" uid="uid://cxe2gscg47fbc" path="res://assets/main_menu/buttons/settings_btn.png" id="btn_settings"]
+[ext_resource type="Texture2D" uid="uid://bs412kgr7wtg3" path="res://assets/main_menu/temp_name.png" id="title_img"]
 
-[sub_resource type="Theme" id="Theme_1g8jr"]
+[sub_resource type="Animation" id="Animation_burn"]
+resource_name = "burn"
+length = 0.84
+loop_mode = 1
+step = 0.12
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Background:texture")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.12, 0.24, 0.36, 0.48, 0.6, 0.72),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1),
+"update": 1,
+"values": [ExtResource("bg_1"), ExtResource("bg_2"), ExtResource("bg_3"), ExtResource("bg_4"), ExtResource("bg_5"), ExtResource("bg_6"), ExtResource("bg_7")]
+}
 
-[sub_resource type="Theme" id="Theme_uhagc"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_btxxm"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_wb0q5"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_q85j6"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8g5eo"]
-
-[sub_resource type="Theme" id="Theme_7suek"]
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_main"]
+_data = {
+&"burn": SubResource("Animation_burn")
+}
 
 [node name="MainMenu" type="Control" unique_id=413469708]
 layout_mode = 3
@@ -28,95 +48,80 @@ grow_vertical = 2
 theme = ExtResource("1_m1kxf")
 script = ExtResource("1_x2yvf")
 
-[node name="Background" type="TextureRect" parent="." unique_id=649349293]
+[node name="Background" type="TextureRect" parent="." unique_id=1394589516]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-texture = ExtResource("2_uhagc")
-stretch_mode = 4
+texture = ExtResource("bg_1")
+expand_mode = 1
+stretch_mode = 5
 
-[node name="ColorRect" type="ColorRect" parent="." unique_id=1526207557]
+[node name="AnimationPlayer" type="AnimationPlayer" parent="." unique_id=354424833]
+libraries/ = SubResource("AnimationLibrary_main")
+autoplay = &"burn"
+
+[node name="TitleImage" type="TextureRect" parent="." unique_id=1271069246]
 layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -350.0
+offset_top = 250.0
+offset_right = 350.0
+offset_bottom = 380.0
+grow_horizontal = 2
+texture = ExtResource("title_img")
+expand_mode = 1
+stretch_mode = 5
+
+[node name="ButtonContainer" type="Control" parent="." unique_id=1723836413]
+layout_mode = 1
+anchor_left = 0.5
+anchor_top = 0.58
+anchor_right = 0.5
+anchor_bottom = 0.58
+offset_left = -100.0
+offset_right = 100.0
 grow_horizontal = 2
 grow_vertical = 2
-color = Color(0.3523784, 0.41394415, 0.6663396, 0.20392157)
 
-[node name="MarginContainer" type="MarginContainer" parent="." unique_id=1638772823]
+[node name="VBoxContainer" type="VBoxContainer" parent="ButtonContainer" unique_id=1627404243]
 layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = -53.0
-offset_top = 45.0
-offset_right = -491.0
-offset_bottom = -858.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -100.0
+offset_top = -100.0
+offset_right = 100.0
+offset_bottom = 160.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/margin_left = 100
-theme_override_constants/margin_bottom = 150
+theme_override_constants/separation = 8
+alignment = 1
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer" unique_id=761723636]
-layout_mode = 2
-alignment = 2
-
-[node name="Title" type="Label" parent="MarginContainer/VBoxContainer" unique_id=1065636741]
-layout_mode = 2
-theme = SubResource("Theme_1g8jr")
-theme_type_variation = &"TitleLabel"
-text = "PROJECT ANINO"
-
-[node name="Subtitle" type="Label" parent="MarginContainer/VBoxContainer" unique_id=37371089]
-layout_mode = 2
-theme_type_variation = &"SubtitleLabel"
-text = "Sa pagitan ng liwanag at dilim"
-
-[node name="Spacer" type="Control" parent="MarginContainer/VBoxContainer" unique_id=1539255336]
-custom_minimum_size = Vector2(0, 320)
-layout_mode = 2
-
-[node name="PlayButton" type="Button" parent="MarginContainer/VBoxContainer" unique_id=122197049]
+[node name="PlayButton" type="TextureButton" parent="ButtonContainer/VBoxContainer" unique_id=122197049]
 layout_mode = 2
 focus_neighbor_bottom = NodePath("../Load")
-theme = SubResource("Theme_uhagc")
-theme_type_variation = &"MainButton"
-theme_override_styles/normal = SubResource("StyleBoxFlat_btxxm")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_wb0q5")
-theme_override_styles/hover = SubResource("StyleBoxFlat_q85j6")
-theme_override_styles/disabled = SubResource("StyleBoxFlat_8g5eo")
-text = "Play Now"
-flat = true
-alignment = 0
+texture_normal = ExtResource("btn_play")
 
-[node name="Load" type="Button" parent="MarginContainer/VBoxContainer" unique_id=1968399434]
+[node name="Load" type="TextureButton" parent="ButtonContainer/VBoxContainer" unique_id=1968399434]
 layout_mode = 2
 focus_neighbor_top = NodePath("../PlayButton")
 focus_neighbor_bottom = NodePath("../SettingsButton")
-theme = SubResource("Theme_7suek")
-theme_type_variation = &"MainButton"
-disabled = true
-text = "Load Game"
-flat = true
-alignment = 0
+texture_normal = ExtResource("btn_load")
 
-[node name="SettingsButton" type="Button" parent="MarginContainer/VBoxContainer" unique_id=1073779884]
+[node name="SettingsButton" type="TextureButton" parent="ButtonContainer/VBoxContainer" unique_id=1073779884]
 layout_mode = 2
 focus_neighbor_top = NodePath("../Load")
 focus_neighbor_bottom = NodePath("../QuitButton")
-theme_type_variation = &"MainButton"
-text = "Settings"
-flat = true
-alignment = 0
+texture_normal = ExtResource("btn_settings")
 
-[node name="QuitButton" type="Button" parent="MarginContainer/VBoxContainer" unique_id=1166346942]
+[node name="QuitButton" type="TextureButton" parent="ButtonContainer/VBoxContainer" unique_id=1166346942]
 layout_mode = 2
 focus_neighbor_top = NodePath("../SettingsButton")
-theme_type_variation = &"MainButton"
-text = "Quit"
-flat = true
-alignment = 0
+texture_normal = ExtResource("btn_quit")

--- a/scenes/ui/settings_menu.gd
+++ b/scenes/ui/settings_menu.gd
@@ -1,7 +1,7 @@
 extends Control
 
 # Reference the back button
-@onready var back_button = $MarginContainer/VBoxContainer/back_button
+@onready var back_button = $MarginContainer/VBoxContainer/BackButton
 
 func _ready():
 	# Connect the button click to the function below

--- a/src/autoload/SceneManager.gd
+++ b/src/autoload/SceneManager.gd
@@ -10,77 +10,77 @@ extends Node
 var _current_index := -1
 
 func _ready() -> void:
-    if advance_on_dialogue_finished:
-        EventBus.dialogue_finished.connect(_on_chapter_finished)
+	if advance_on_dialogue_finished:
+		EventBus.dialogue_finished.connect(_on_chapter_finished)
 
 func _exit_tree() -> void:
-    if EventBus.dialogue_finished.is_connected(_on_chapter_finished):
-        EventBus.dialogue_finished.disconnect(_on_chapter_finished)
+	if EventBus.dialogue_finished.is_connected(_on_chapter_finished):
+		EventBus.dialogue_finished.disconnect(_on_chapter_finished)
 
 func _unhandled_input(event: InputEvent) -> void:
-    if not debug_input_enabled:
-        return
-    if event.is_action_pressed(debug_next_action):
-        next_chapter()
+	if not debug_input_enabled:
+		return
+	if event.is_action_pressed(debug_next_action):
+		next_chapter()
 
 func request_scene_change(target_path: String, background_id: String = "") -> void:
-    if target_path.is_empty():
-        push_warning("SceneManager received an empty target path.")
-        return
+	if target_path.is_empty():
+		push_warning("SceneManager received an empty target path.")
+		return
 
-    if background_first and not background_id.is_empty():
-        EventBus.background_change_requested.emit(background_id)
+	if background_first and not background_id.is_empty():
+		EventBus.background_change_requested.emit(background_id)
 
-    EventBus.scene_change_requested.emit(target_path)
+	EventBus.scene_change_requested.emit(target_path)
 
-    if not background_first and not background_id.is_empty():
-        EventBus.background_change_requested.emit(background_id)
+	if not background_first and not background_id.is_empty():
+		EventBus.background_change_requested.emit(background_id)
 
 func go_to_chapter(chapter_id: String) -> void:
-    if not chapters.has(chapter_id):
-        push_warning("Unknown chapter id: %s" % chapter_id)
-        return
+	if not chapters.has(chapter_id):
+		push_warning("Unknown chapter id: %s" % chapter_id)
+		return
 
-    var chapter = chapters.get(chapter_id, {})
-    var target_path := ""
-    var background_id := ""
+	var chapter = chapters.get(chapter_id, {})
+	var target_path := ""
+	var background_id := ""
 
-    if typeof(chapter) == TYPE_DICTIONARY:
-        target_path = chapter.get("scene", "")
-        background_id = chapter.get("background", "")
+	if typeof(chapter) == TYPE_DICTIONARY:
+		target_path = chapter.get("scene", "")
+		background_id = chapter.get("background", "")
 
-    request_scene_change(target_path, background_id)
+	request_scene_change(target_path, background_id)
 
 func start_sequence() -> void:
-    _current_index = -1
-    next_chapter()
+	_current_index = -1
+	next_chapter()
 
 func next_chapter() -> void:
-    if sequence.is_empty():
-        push_warning("SceneManager sequence is empty.")
-        return
+	if sequence.is_empty():
+		push_warning("SceneManager sequence is empty.")
+		return
 
-    _current_index += 1
-    if _current_index >= sequence.size():
-        push_warning("SceneManager reached the end of the sequence.")
-        return
+	_current_index += 1
+	if _current_index >= sequence.size():
+		push_warning("SceneManager reached the end of the sequence.")
+		return
 
-    _run_sequence_entry(sequence[_current_index])
+	_run_sequence_entry(sequence[_current_index])
 
 func _run_sequence_entry(entry: String) -> void:
-    if chapters.has(entry):
-        var chapter = chapters.get(entry, {})
-        var target_path := ""
-        var background_id := ""
+	if chapters.has(entry):
+		var chapter = chapters.get(entry, {})
+		var target_path := ""
+		var background_id := ""
 
-        if typeof(chapter) == TYPE_DICTIONARY:
-            target_path = chapter.get("scene", "")
-            background_id = chapter.get("background", "")
+		if typeof(chapter) == TYPE_DICTIONARY:
+			target_path = chapter.get("scene", "")
+			background_id = chapter.get("background", "")
 
-        request_scene_change(target_path, background_id)
-        return
+		request_scene_change(target_path, background_id)
+		return
 
-    request_scene_change(entry)
+	request_scene_change(entry)
 
 func _on_chapter_finished() -> void:
-    next_chapter()
+	next_chapter()

--- a/src/ui/load_game.gd
+++ b/src/ui/load_game.gd
@@ -1,0 +1,27 @@
+extends Control
+
+@onready var back_button = $BackButton
+@onready var load_btns = [$CenterContainer/SlotList/Slot1/SlotHBox1/ButtonsHBox/LoadBtn1,
+	$CenterContainer/SlotList/Slot2/SlotHBox2/ButtonsHBox/LoadBtn2,
+	$CenterContainer/SlotList/Slot3/SlotHBox3/ButtonsHBox/LoadBtn3]
+@onready var delete_btns = [$CenterContainer/SlotList/Slot1/SlotHBox1/ButtonsHBox/DeleteBtn1,
+	$CenterContainer/SlotList/Slot2/SlotHBox2/ButtonsHBox/DeleteBtn2,
+	$CenterContainer/SlotList/Slot3/SlotHBox3/ButtonsHBox/DeleteBtn3]
+
+func _ready():
+	back_button.pressed.connect(_on_back_pressed)
+	for i in range(3):
+		var slot_index = i
+		load_btns[i].pressed.connect(func(): _on_load_pressed(slot_index))
+		delete_btns[i].pressed.connect(func(): _on_delete_pressed(slot_index))
+
+func _on_back_pressed():
+	get_tree().change_scene_to_file("res://scenes/ui/main_menu.tscn")
+
+func _on_load_pressed(slot: int):
+	# TODO: implement save data loading for slot
+	print("Load slot: ", slot + 1)
+
+func _on_delete_pressed(slot: int):
+	# TODO: implement save data deletion for slot
+	print("Delete slot: ", slot + 1)

--- a/src/ui/main_menu.gd
+++ b/src/ui/main_menu.gd
@@ -1,20 +1,25 @@
 extends Control
 
-@onready var play_button = $MarginContainer/VBoxContainer/PlayButton
-@onready var settings_button = $MarginContainer/VBoxContainer/SettingsButton
-@onready var quit_button = $MarginContainer/VBoxContainer/QuitButton
+@onready var play_button = $ButtonContainer/VBoxContainer/PlayButton
+@onready var load_button = $ButtonContainer/VBoxContainer/Load
+@onready var settings_button = $ButtonContainer/VBoxContainer/SettingsButton
+@onready var quit_button = $ButtonContainer/VBoxContainer/QuitButton
+@onready var animation_player = $AnimationPlayer
 
 func _ready():
 	play_button.pressed.connect(_on_play_pressed)
+	load_button.pressed.connect(_on_load_pressed)
 	settings_button.pressed.connect(_on_settings_pressed)
 	quit_button.pressed.connect(_on_quit_pressed)
+	animation_player.play("burn")
 
 func _on_play_pressed():
-	# Make sure this file name is exactly correct!
-	get_tree().change_scene_to_file("res://scenes/templates/chapter_1.tscn")
+	get_tree().change_scene_to_file("res://scenes/ui/map_selection.tscn")
+
+func _on_load_pressed():
+	get_tree().change_scene_to_file("res://scenes/ui/load_game.tscn")
 
 func _on_settings_pressed():
-	# Points to the new scene we made in Step 4
 	get_tree().change_scene_to_file("res://scenes/ui/settings_menu.tscn")
 
 func _on_quit_pressed():


### PR DESCRIPTION
## Description
Revamped the main menu UI to use real game assets. Replaced the placeholder 
grass background and text buttons with the animated burning mountain background 
and scroll-style button images. Added the game title image. Wired up all button 
navigation. Fixed settings menu back button path mismatch. Created the load game 
scene with 3 save slots.

## Related Issue
Closes #

## Type of Change
- [x] feat: New feature
- [x] fix: Bug fix

## Testing
- Tested in Godot 4.6.2 stable at 1280x800
- Play Now → navigates to map_selection.tscn ✓
- Load Game → navigates to load_game.tscn ✓
- Settings → navigates to settings_menu.tscn ✓
- Back button in Settings → returns to main_menu.tscn ✓
- Quit → closes the game ✓
- Animated background cycles through burning_mountain_1-7.png ✓

## Checklist
- [x] My commit messages follow the Conventional Commits format
- [x] I have tested my changes in Godot
- [ ] I have updated documentation if needed
- [x] I have not broken any existing functionality